### PR TITLE
Add Celo Consistency Frame for GitHub contribution tracking

### DIFF
--- a/celo-consistency-frame/README.md
+++ b/celo-consistency-frame/README.md
@@ -1,0 +1,88 @@
+# Celo Consistency Frame
+
+A Farcaster Frame that showcases your consistency in building on Celo through GitHub contributions.
+
+## Features
+
+- 📊 **GitHub Contribution Visualization**: Display your GitHub contribution activity in a clean, visual format.
+- 📈 **Weekly Summary**: Track your weekly contribution progress and compare it with previous weeks.
+- 🏆 **Leaderboard**: Compete with other Celo developers on a leaderboard.
+- 🔥 **Streak Tracking**: Keep track of your contribution streaks to stay motivated.
+- 🔔 **Notifications**: Get weekly updates on your position on the leaderboard.
+
+## How It Works
+
+1. **Add your GitHub profile**: Connect your GitHub account to start tracking your consistency.
+2. **Show your weekly activity**: View your GitHub contributions in a visually appealing frame.
+3. **Weekly notifications**: Get updates on your position on the leaderboard.
+4. **Track your streaks**: Monitor your daily contribution streaks, similar to Duolingo's streak system.
+5. **Optional rewards**: Top 10 builders may receive weekly rewards (implementation up to the community).
+
+## Technical Implementation
+
+### Prerequisites
+
+- Node.js (v16 or higher)
+- npm or yarn
+- A GitHub personal access token for API access
+
+### Environment Setup
+
+Create a `.env` file in the root directory with the following content:
+
+```
+GITHUB_TOKEN=your_github_personal_access_token
+NEXT_PUBLIC_HOST=http://localhost:3000
+```
+
+In production, set `NEXT_PUBLIC_HOST` to your deployed application URL.
+
+### Installation
+
+```bash
+# Install dependencies
+npm install
+
+# Run development server
+npm run dev
+
+# Build for production
+npm run build
+
+# Start production server
+npm start
+```
+
+### Technology Stack
+
+- **Next.js**: React framework for the web application
+- **TypeScript**: Type-safe JavaScript
+- **Tailwind CSS**: Utility-first CSS framework
+- **Canvas**: For generating frame images
+- **GitHub API**: For fetching contribution data
+- **Farcaster Frames Protocol**: For creating interactive frames
+
+## Deployment
+
+This application can be deployed to platforms like Vercel or Netlify. Make sure to set the environment variables in your deployment platform.
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+1. Fork the repository
+2. Create a new branch: `git checkout -b feature/my-feature`
+3. Make your changes
+4. Commit your changes: `git commit -m 'Add some feature'`
+5. Push to the branch: `git push origin feature/my-feature`
+6. Open a Pull Request
+
+## License
+
+This project is licensed under the MIT License - see the LICENSE file for details.
+
+## Acknowledgements
+
+- Built for the Celo community
+- Inspired by GitHub's contribution graph
+- Thanks to the Farcaster team for the frames protocol

--- a/celo-consistency-frame/next.config.js
+++ b/celo-consistency-frame/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  images: {
+    domains: ['avatars.githubusercontent.com', 'github.com'],
+  },
+};
+
+module.exports = nextConfig;

--- a/celo-consistency-frame/package.json
+++ b/celo-consistency-frame/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "celo-consistency-frame",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "axios": "^1.6.2",
+    "cheerio": "^1.0.0-rc.12",
+    "date-fns": "^2.30.0",
+    "dotenv": "^16.3.1",
+    "frog": "^0.5.5",
+    "hono": "^3.10.2",
+    "next": "14.0.3",
+    "react": "^18",
+    "react-dom": "^18",
+    "recharts": "^2.10.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "autoprefixer": "^10.0.1",
+    "eslint": "^8",
+    "eslint-config-next": "14.0.3",
+    "postcss": "^8",
+    "tailwindcss": "^3.3.0",
+    "typescript": "^5"
+  }
+}

--- a/celo-consistency-frame/src/app/frames/route.tsx
+++ b/celo-consistency-frame/src/app/frames/route.tsx
@@ -1,0 +1,210 @@
+import { Button, FrameContainer, FrameImage, TextInput, useFramesReducer } from 'frames.js/next/server';
+import type { NextRequest } from 'next/server';
+import { saveUser, getUser, updateUserVisit, addToLeaderboard } from '@/utils/db';
+
+// Define the frame state
+type State = {
+  page: 'intro' | 'profile' | 'heatmap' | 'weekly' | 'leaderboard';
+  username?: string;
+};
+
+// Initial state
+const initialState: State = {
+  page: 'intro',
+};
+
+export async function GET(req: NextRequest) {
+  // Parse the URL parameters
+  const searchParams = req.nextUrl.searchParams;
+  const username = searchParams.get('username') || '';
+  
+  // Create the frame with initial state
+  const { frame, state } = useFramesReducer<State>(initialState, reducer);
+  
+  // Determine what to display based on state
+  switch (state.page) {
+    case 'intro':
+      return (
+        <FrameContainer
+          frame={frame}
+          state={state}
+          postUrl="/frames"
+        >
+          <FrameImage>
+            <div style={{ 
+              display: 'flex', 
+              flexDirection: 'column', 
+              alignItems: 'center', 
+              justifyContent: 'center',
+              backgroundColor: '#2E3338',
+              color: 'white',
+              width: '100%',
+              height: '100%',
+              padding: '20px'
+            }}>
+              <h1 style={{ fontSize: '24px', marginBottom: '20px' }}>
+                Show your consistency of building on Celo
+              </h1>
+              <p style={{ fontSize: '16px', textAlign: 'center', marginBottom: '10px' }}>
+                Track your GitHub contribution streak and compete with others in the Celo ecosystem!
+              </p>
+              <div style={{ 
+                display: 'flex', 
+                alignItems: 'center', 
+                justifyContent: 'center',
+                backgroundColor: '#35D07F', 
+                width: '80%',
+                height: '40px',
+                borderRadius: '8px',
+                marginTop: '20px'
+              }}>
+                <p style={{ color: 'white', fontWeight: 'bold' }}>
+                  Enter your GitHub username to start
+                </p>
+              </div>
+            </div>
+          </FrameImage>
+          <TextInput placeholder="Enter your GitHub username" />
+          <Button actionId="submit-username">Submit</Button>
+        </FrameContainer>
+      );
+      
+    case 'profile':
+      return (
+        <FrameContainer
+          frame={frame}
+          state={state}
+          postUrl="/frames"
+        >
+          <FrameImage>
+            <div style={{ 
+              backgroundColor: '#2E3338',
+              color: 'white',
+              width: '100%',
+              height: '100%',
+              padding: '20px'
+            }}>
+              <h1 style={{ fontSize: '24px', marginBottom: '20px' }}>
+                Welcome, {state.username || 'Developer'}!
+              </h1>
+              <p style={{ fontSize: '16px', marginBottom: '10px' }}>
+                What would you like to see?
+              </p>
+              <ul style={{ listStyleType: 'none', padding: 0 }}>
+                <li style={{ marginBottom: '10px' }}>• Contribution Heatmap</li>
+                <li style={{ marginBottom: '10px' }}>• Weekly Summary</li>
+                <li style={{ marginBottom: '10px' }}>• Leaderboard</li>
+              </ul>
+            </div>
+          </FrameImage>
+          <Button actionId="show-heatmap">View Heatmap</Button>
+          <Button actionId="show-weekly">Weekly Summary</Button>
+          <Button actionId="show-leaderboard">View Leaderboard</Button>
+        </FrameContainer>
+      );
+      
+    case 'heatmap':
+      return (
+        <FrameContainer
+          frame={frame}
+          state={state}
+          postUrl="/frames"
+        >
+          <FrameImage src={`${process.env.NEXT_PUBLIC_HOST}/api/heatmap/${state.username}`} />
+          <Button actionId="back-to-profile">Back</Button>
+          <Button actionId="show-weekly">Weekly Summary</Button>
+          <Button actionId="show-leaderboard">Leaderboard</Button>
+        </FrameContainer>
+      );
+      
+    case 'weekly':
+      return (
+        <FrameContainer
+          frame={frame}
+          state={state}
+          postUrl="/frames"
+        >
+          <FrameImage src={`${process.env.NEXT_PUBLIC_HOST}/api/weekly/${state.username}`} />
+          <Button actionId="back-to-profile">Back</Button>
+          <Button actionId="show-heatmap">View Heatmap</Button>
+          <Button actionId="show-leaderboard">Leaderboard</Button>
+        </FrameContainer>
+      );
+      
+    case 'leaderboard':
+      return (
+        <FrameContainer
+          frame={frame}
+          state={state}
+          postUrl="/frames"
+        >
+          <FrameImage src={`${process.env.NEXT_PUBLIC_HOST}/api/leaderboard`} />
+          <Button actionId="back-to-profile">Back</Button>
+          <Button actionId="show-heatmap">View Heatmap</Button>
+          <Button actionId="show-weekly">Weekly Summary</Button>
+        </FrameContainer>
+      );
+  }
+}
+
+// Reducer function to handle actions
+function reducer(state: State, action: any): State {
+  const { buttonIndex, inputText, fid } = action;
+  
+  // Handle the initial username submission
+  if (buttonIndex === 1 && action.actionId === 'submit-username') {
+    const username = inputText.trim();
+    
+    if (username) {
+      // Store the username in our database
+      if (fid) {
+        saveUser(fid.toString(), username);
+        addToLeaderboard(username);
+      }
+      
+      return {
+        ...state,
+        page: 'profile',
+        username,
+      };
+    }
+    
+    return state;
+  }
+  
+  // If a user is returning, update their visit streak
+  if (fid) {
+    updateUserVisit(fid.toString());
+  }
+  
+  // Handle navigation between pages
+  if (buttonIndex === 1 && action.actionId === 'back-to-profile') {
+    return { ...state, page: 'profile' };
+  }
+  
+  if (buttonIndex === 1 && action.actionId === 'show-heatmap') {
+    return { ...state, page: 'heatmap' };
+  }
+  
+  if (buttonIndex === 2 && action.actionId === 'show-weekly') {
+    return { ...state, page: 'weekly' };
+  }
+  
+  if (buttonIndex === 3 || (buttonIndex === 2 && action.actionId === 'show-leaderboard')) {
+    return { ...state, page: 'leaderboard' };
+  }
+  
+  return state;
+}
+
+// POST handler for frame actions
+export async function POST(req: Request) {
+  const body = await req.json();
+  const { frame, state, action } = await useFramesReducer<State>(
+    initialState,
+    reducer,
+    body
+  );
+  
+  return frame.response(state);
+}

--- a/celo-consistency-frame/src/pages/api/heatmap/[username].ts
+++ b/celo-consistency-frame/src/pages/api/heatmap/[username].ts
@@ -1,0 +1,28 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { fetchContributionData, fetchGitHubUserData, calculateStreakInfo } from '@/utils/githubUtils';
+import { generateContributionHeatmap } from '@/utils/imageUtils';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const { username } = req.query;
+    
+    if (!username || typeof username !== 'string') {
+      return res.status(400).json({ error: 'GitHub username is required' });
+    }
+    
+    // Fetch user and contribution data
+    const userData = await fetchGitHubUserData(username);
+    const contributionData = await fetchContributionData(username);
+    
+    // Generate the heatmap image
+    const imageBuffer = await generateContributionHeatmap(contributionData, userData);
+    
+    // Set the correct content type and send the image
+    res.setHeader('Content-Type', 'image/png');
+    res.setHeader('Cache-Control', 'public, max-age=3600'); // Cache for 1 hour
+    res.send(imageBuffer);
+  } catch (error) {
+    console.error('Error generating heatmap:', error);
+    res.status(500).json({ error: 'Failed to generate contribution heatmap' });
+  }
+}

--- a/celo-consistency-frame/src/pages/api/leaderboard.ts
+++ b/celo-consistency-frame/src/pages/api/leaderboard.ts
@@ -1,0 +1,29 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getLeaderboard } from '@/utils/githubUtils';
+import { generateLeaderboard as generateLeaderboardImage } from '@/utils/imageUtils';
+import { getLeaderboard as getLeaderboardFromDB } from '@/utils/db';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    // Get the list of GitHub usernames from our database
+    const usernames = getLeaderboardFromDB();
+    
+    if (usernames.length === 0) {
+      return res.status(404).json({ error: 'No users on the leaderboard yet' });
+    }
+    
+    // Get contribution data for the leaderboard
+    const leaderboardData = await getLeaderboard(usernames);
+    
+    // Generate the leaderboard image
+    const imageBuffer = await generateLeaderboardImage(leaderboardData);
+    
+    // Set the correct content type and send the image
+    res.setHeader('Content-Type', 'image/png');
+    res.setHeader('Cache-Control', 'public, max-age=3600'); // Cache for 1 hour
+    res.send(imageBuffer);
+  } catch (error) {
+    console.error('Error generating leaderboard:', error);
+    res.status(500).json({ error: 'Failed to generate leaderboard' });
+  }
+}

--- a/celo-consistency-frame/src/pages/api/weekly/[username].ts
+++ b/celo-consistency-frame/src/pages/api/weekly/[username].ts
@@ -1,0 +1,31 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { fetchContributionData, fetchGitHubUserData, calculateStreakInfo } from '@/utils/githubUtils';
+import { generateWeeklySummary } from '@/utils/imageUtils';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const { username } = req.query;
+    
+    if (!username || typeof username !== 'string') {
+      return res.status(400).json({ error: 'GitHub username is required' });
+    }
+    
+    // Fetch user and contribution data
+    const userData = await fetchGitHubUserData(username);
+    const contributionData = await fetchContributionData(username);
+    
+    // Calculate streak information
+    const streakInfo = calculateStreakInfo(contributionData);
+    
+    // Generate the weekly summary image
+    const imageBuffer = await generateWeeklySummary(contributionData, userData, streakInfo);
+    
+    // Set the correct content type and send the image
+    res.setHeader('Content-Type', 'image/png');
+    res.setHeader('Cache-Control', 'public, max-age=3600'); // Cache for 1 hour
+    res.send(imageBuffer);
+  } catch (error) {
+    console.error('Error generating weekly summary:', error);
+    res.status(500).json({ error: 'Failed to generate weekly summary' });
+  }
+}

--- a/celo-consistency-frame/src/pages/index.tsx
+++ b/celo-consistency-frame/src/pages/index.tsx
@@ -1,0 +1,161 @@
+import { NextPage } from 'next';
+import { useState } from 'react';
+import Head from 'next/head';
+import Image from 'next/image';
+
+const Home: NextPage = () => {
+  const [username, setUsername] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [frameUrl, setFrameUrl] = useState('');
+  
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!username) return;
+    
+    setIsLoading(true);
+    
+    try {
+      // Generate the frame URL
+      const host = process.env.NEXT_PUBLIC_HOST || window.location.origin;
+      const url = `${host}/frames?username=${encodeURIComponent(username)}`;
+      setFrameUrl(url);
+    } catch (error) {
+      console.error('Error:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+  
+  return (
+    <div className="min-h-screen bg-gray-900 text-white">
+      <Head>
+        <title>Celo Consistency Frame</title>
+        <meta name="description" content="Track your consistency of building on Celo" />
+        <link rel="icon" href="/favicon.ico" />
+        
+        {/* Frame metadata */}
+        {frameUrl && (
+          <>
+            <meta property="fc:frame" content="vNext" />
+            <meta property="fc:frame:image" content={`${process.env.NEXT_PUBLIC_HOST}/api/heatmap/${username}`} />
+            <meta property="fc:frame:button:1" content="View Heatmap" />
+            <meta property="fc:frame:button:2" content="Weekly Summary" />
+            <meta property="fc:frame:button:3" content="Leaderboard" />
+            <meta property="fc:frame:post_url" content={frameUrl} />
+          </>
+        )}
+      </Head>
+      
+      <main className="container mx-auto px-4 py-16">
+        <div className="max-w-3xl mx-auto">
+          <div className="text-center mb-12">
+            <h1 className="text-4xl font-bold mb-4">Celo Consistency Frame</h1>
+            <p className="text-xl text-gray-300">
+              Track your GitHub consistency and compete with other Celo developers
+            </p>
+          </div>
+          
+          <div className="bg-gray-800 p-8 rounded-lg shadow-lg">
+            <h2 className="text-2xl font-semibold mb-6">Generate Your Frame</h2>
+            
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label htmlFor="username" className="block text-sm font-medium mb-2">
+                  GitHub Username
+                </label>
+                <input
+                  type="text"
+                  id="username"
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  className="w-full px-4 py-2 bg-gray-700 border border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-celo-green"
+                  placeholder="Enter your GitHub username"
+                  required
+                />
+              </div>
+              
+              <button
+                type="submit"
+                disabled={isLoading}
+                className="w-full bg-celo-green hover:bg-opacity-90 text-white font-medium py-2 px-4 rounded-md transition-colors"
+              >
+                {isLoading ? 'Loading...' : 'Generate Frame'}
+              </button>
+            </form>
+            
+            {frameUrl && (
+              <div className="mt-8 p-4 bg-gray-700 rounded-md">
+                <h3 className="text-lg font-medium mb-2">Your Frame URL</h3>
+                <div className="flex">
+                  <input
+                    type="text"
+                    value={frameUrl}
+                    readOnly
+                    className="flex-grow px-3 py-2 bg-gray-800 border border-gray-600 rounded-l-md focus:outline-none"
+                  />
+                  <button
+                    onClick={() => {
+                      navigator.clipboard.writeText(frameUrl);
+                      alert('URL copied to clipboard!');
+                    }}
+                    className="bg-celo-green px-4 py-2 rounded-r-md hover:bg-opacity-90"
+                  >
+                    Copy
+                  </button>
+                </div>
+                
+                <div className="mt-6">
+                  <h4 className="text-md font-medium mb-2">Preview</h4>
+                  <div className="border border-gray-600 rounded-md overflow-hidden">
+                    <Image
+                      src={`/api/heatmap/${username}`}
+                      alt="Frame Preview"
+                      width={600}
+                      height={320}
+                      className="w-full h-auto"
+                    />
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+          
+          <div className="mt-12 bg-gray-800 p-8 rounded-lg shadow-lg">
+            <h2 className="text-2xl font-semibold mb-4">How It Works</h2>
+            
+            <div className="space-y-4">
+              <div>
+                <h3 className="text-xl font-medium">1. Add your GitHub profile</h3>
+                <p className="text-gray-300">Enter your GitHub username to generate your consistency frame.</p>
+              </div>
+              
+              <div>
+                <h3 className="text-xl font-medium">2. Share your weekly activity</h3>
+                <p className="text-gray-300">Your frame will display your GitHub contribution activity in a Farcaster frame.</p>
+              </div>
+              
+              <div>
+                <h3 className="text-xl font-medium">3. Join the leaderboard</h3>
+                <p className="text-gray-300">Compete with other Celo developers and track your streak.</p>
+              </div>
+              
+              <div>
+                <h3 className="text-xl font-medium">4. Stay consistent</h3>
+                <p className="text-gray-300">Build your streak by consistently contributing to GitHub repositories.</p>
+              </div>
+            </div>
+          </div>
+          
+          <div className="mt-12 text-center">
+            <p className="text-gray-400">
+              Built for the Celo community. Share your building journey on Farcaster.
+            </p>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default Home;

--- a/celo-consistency-frame/src/utils/db.ts
+++ b/celo-consistency-frame/src/utils/db.ts
@@ -1,0 +1,78 @@
+// Simple in-memory storage for demo purposes
+// In a production environment, this would be replaced with a proper database
+
+export interface UserState {
+  fid: string;
+  githubUsername: string;
+  lastVisit: Date;
+  streak: number;
+}
+
+interface DB {
+  users: Map<string, UserState>;
+  leaderboard: string[]; // Array of GitHub usernames for the leaderboard
+}
+
+// Initialize the database
+const db: DB = {
+  users: new Map<string, UserState>(),
+  leaderboard: [],
+};
+
+// User methods
+export const saveUser = (fid: string, githubUsername: string): void => {
+  const existingUser = db.users.get(fid);
+  
+  db.users.set(fid, {
+    fid,
+    githubUsername,
+    lastVisit: new Date(),
+    streak: existingUser?.streak || 1,
+  });
+  
+  // Add to the leaderboard if not already present
+  if (!db.leaderboard.includes(githubUsername)) {
+    db.leaderboard.push(githubUsername);
+  }
+};
+
+export const getUser = (fid: string): UserState | undefined => {
+  return db.users.get(fid);
+};
+
+export const updateUserVisit = (fid: string): void => {
+  const user = db.users.get(fid);
+  if (user) {
+    // Calculate if this is a new day since last visit
+    const lastVisitDate = new Date(user.lastVisit);
+    const today = new Date();
+    
+    const isNewDay = 
+      lastVisitDate.getDate() !== today.getDate() || 
+      lastVisitDate.getMonth() !== today.getMonth() || 
+      lastVisitDate.getFullYear() !== today.getFullYear();
+    
+    db.users.set(fid, {
+      ...user,
+      lastVisit: today,
+      streak: isNewDay ? user.streak + 1 : user.streak,
+    });
+  }
+};
+
+// Leaderboard methods
+export const getLeaderboard = (): string[] => {
+  return [...db.leaderboard];
+};
+
+export const addToLeaderboard = (githubUsername: string): void => {
+  if (!db.leaderboard.includes(githubUsername)) {
+    db.leaderboard.push(githubUsername);
+  }
+};
+
+// Reset database - for testing purposes
+export const resetDB = (): void => {
+  db.users.clear();
+  db.leaderboard = [];
+};

--- a/celo-consistency-frame/src/utils/githubUtils.ts
+++ b/celo-consistency-frame/src/utils/githubUtils.ts
@@ -1,0 +1,175 @@
+import axios from 'axios';
+
+const GITHUB_API = 'https://api.github.com';
+
+// Interface for GitHub contribution data
+export interface ContributionDay {
+  date: string;
+  count: number;
+  level: number;
+}
+
+export interface ContributionWeek {
+  days: ContributionDay[];
+}
+
+export interface ContributionData {
+  weeks: ContributionWeek[];
+  totalContributions: number;
+}
+
+export interface UserData {
+  username: string;
+  avatarUrl: string;
+  name: string;
+  bio: string;
+}
+
+// Fetch user data from GitHub
+export const fetchGitHubUserData = async (username: string): Promise<UserData> => {
+  try {
+    const token = process.env.GITHUB_TOKEN;
+    const headers = token ? { Authorization: `token ${token}` } : {};
+    
+    const response = await axios.get(`${GITHUB_API}/users/${username}`, { headers });
+    
+    return {
+      username: response.data.login,
+      avatarUrl: response.data.avatar_url,
+      name: response.data.name || response.data.login,
+      bio: response.data.bio || '',
+    };
+  } catch (error) {
+    console.error('Error fetching GitHub user data:', error);
+    throw new Error('Failed to fetch GitHub user data');
+  }
+};
+
+// Fetch contribution data for the last year
+export const fetchContributionData = async (username: string): Promise<ContributionData> => {
+  try {
+    // Using GitHub's GraphQL API to get contribution data
+    const token = process.env.GITHUB_TOKEN;
+    
+    if (!token) {
+      throw new Error('GitHub token is required for fetching contribution data');
+    }
+    
+    const query = `
+      query {
+        user(login: "${username}") {
+          contributionsCollection {
+            contributionCalendar {
+              totalContributions
+              weeks {
+                contributionDays {
+                  date
+                  contributionCount
+                  contributionLevel
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+    
+    const response = await axios.post(
+      'https://api.github.com/graphql',
+      { query },
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+    
+    const data = response.data.data.user.contributionsCollection.contributionCalendar;
+    
+    // Process the data into our format
+    const weeks: ContributionWeek[] = data.weeks.map((week: any) => ({
+      days: week.contributionDays.map((day: any) => ({
+        date: day.date,
+        count: day.contributionCount,
+        level: getLevelFromContributionLevel(day.contributionLevel),
+      })),
+    }));
+    
+    return {
+      weeks,
+      totalContributions: data.totalContributions,
+    };
+  } catch (error) {
+    console.error('Error fetching contribution data:', error);
+    throw new Error('Failed to fetch contribution data');
+  }
+};
+
+// Helper to convert GitHub's contribution level to a number
+const getLevelFromContributionLevel = (level: string): number => {
+  switch (level) {
+    case 'NONE': return 0;
+    case 'FIRST_QUARTILE': return 1;
+    case 'SECOND_QUARTILE': return 2;
+    case 'THIRD_QUARTILE': return 3;
+    case 'FOURTH_QUARTILE': return 4;
+    default: return 0;
+  }
+};
+
+// Calculate streak information
+export const calculateStreakInfo = (contributionData: ContributionData) => {
+  if (!contributionData || !contributionData.weeks) {
+    return { currentStreak: 0, longestStreak: 0 };
+  }
+
+  let currentStreak = 0;
+  let longestStreak = 0;
+  let tempStreak = 0;
+  
+  // Flatten all days
+  const allDays = contributionData.weeks.flatMap(week => week.days);
+  
+  // Sort by date
+  allDays.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  
+  // Calculate streaks
+  for (let i = allDays.length - 1; i >= 0; i--) {
+    if (allDays[i].count > 0) {
+      tempStreak++;
+      
+      // If this is the most recent day with contributions, update current streak
+      if (i === allDays.length - 1) {
+        currentStreak = tempStreak;
+      }
+    } else {
+      tempStreak = 0;
+    }
+    
+    longestStreak = Math.max(longestStreak, tempStreak);
+  }
+  
+  return { currentStreak, longestStreak };
+};
+
+// Get leaderboard data
+export const getLeaderboard = async (usernames: string[]): Promise<Array<{username: string, contributions: number}>> => {
+  try {
+    const leaderboardData = await Promise.all(
+      usernames.map(async (username) => {
+        try {
+          const data = await fetchContributionData(username);
+          return {
+            username,
+            contributions: data.totalContributions,
+          };
+        } catch (error) {
+          console.error(`Error fetching data for ${username}:`, error);
+          return { username, contributions: 0 };
+        }
+      })
+    );
+    
+    // Sort by contributions (descending)
+    return leaderboardData.sort((a, b) => b.contributions - a.contributions);
+  } catch (error) {
+    console.error('Error generating leaderboard:', error);
+    return [];
+  }
+};

--- a/celo-consistency-frame/src/utils/imageUtils.ts
+++ b/celo-consistency-frame/src/utils/imageUtils.ts
@@ -1,0 +1,188 @@
+import { createCanvas } from 'canvas';
+import type { ContributionData, UserData } from './githubUtils';
+
+// Generate contribution heatmap image
+export const generateContributionHeatmap = async (
+  contributionData: ContributionData,
+  userData: UserData
+): Promise<Buffer> => {
+  // Canvas dimensions
+  const width = 600;
+  const height = 320;
+  const cellSize = 12;
+  const cellGap = 2;
+  
+  // Create canvas
+  const canvas = createCanvas(width, height);
+  const ctx = canvas.getContext('2d');
+  
+  // Fill background
+  ctx.fillStyle = '#2E3338'; // Celo dark color
+  ctx.fillRect(0, 0, width, height);
+  
+  // Add title
+  ctx.fillStyle = '#FFFFFF';
+  ctx.font = 'bold 16px Arial';
+  ctx.fillText(`${userData.name}'s GitHub Contributions`, 20, 30);
+  
+  // Add total contributions
+  ctx.font = '14px Arial';
+  ctx.fillText(`Total Contributions: ${contributionData.totalContributions}`, 20, 50);
+  
+  // Draw contribution grid
+  const startX = 20;
+  const startY = 70;
+  const colors = ['#161B22', '#0E4429', '#006D32', '#26A641', '#39D353']; // GitHub-like colors
+  
+  let weekIndex = contributionData.weeks.length - 52; // Show last year (52 weeks)
+  if (weekIndex < 0) weekIndex = 0;
+  
+  for (let i = 0; i < Math.min(52, contributionData.weeks.length); i++) {
+    const week = contributionData.weeks[weekIndex + i];
+    
+    for (let j = 0; j < week.days.length; j++) {
+      const day = week.days[j];
+      const x = startX + i * (cellSize + cellGap);
+      const y = startY + j * (cellSize + cellGap);
+      
+      // Fill cell based on contribution level
+      ctx.fillStyle = colors[day.level];
+      ctx.fillRect(x, y, cellSize, cellSize);
+    }
+  }
+  
+  // Add Celo logo
+  ctx.fillStyle = '#35D07F'; // Celo green
+  ctx.font = 'bold 12px Arial';
+  ctx.fillText('Built on Celo', width - 110, height - 20);
+  
+  // Convert canvas to buffer
+  return canvas.toBuffer('image/png');
+};
+
+// Generate weekly summary image
+export const generateWeeklySummary = async (
+  contributionData: ContributionData,
+  userData: UserData,
+  streakInfo: { currentStreak: number; longestStreak: number }
+): Promise<Buffer> => {
+  // Canvas dimensions
+  const width = 600;
+  const height = 320;
+  
+  // Create canvas
+  const canvas = createCanvas(width, height);
+  const ctx = canvas.getContext('2d');
+  
+  // Fill background
+  ctx.fillStyle = '#2E3338'; // Celo dark color
+  ctx.fillRect(0, 0, width, height);
+  
+  // Add title
+  ctx.fillStyle = '#FFFFFF';
+  ctx.font = 'bold 20px Arial';
+  ctx.fillText(`${userData.name}'s Weekly Summary`, 20, 40);
+  
+  // Calculate this week's contributions
+  const recentWeeks = contributionData.weeks.slice(-8); // Get the last 8 weeks
+  const thisWeekContributions = recentWeeks[recentWeeks.length - 1]?.days.reduce(
+    (sum, day) => sum + day.count, 0
+  ) || 0;
+  
+  // Calculate last week's contributions
+  const lastWeekContributions = recentWeeks[recentWeeks.length - 2]?.days.reduce(
+    (sum, day) => sum + day.count, 0
+  ) || 0;
+  
+  // Display weekly stats
+  ctx.font = '16px Arial';
+  ctx.fillText(`This Week: ${thisWeekContributions} contributions`, 20, 80);
+  ctx.fillText(`Last Week: ${lastWeekContributions} contributions`, 20, 110);
+  
+  // Calculate change percentage
+  let changeText = 'No change';
+  if (lastWeekContributions > 0) {
+    const change = ((thisWeekContributions - lastWeekContributions) / lastWeekContributions) * 100;
+    if (change > 0) {
+      changeText = `↑ ${change.toFixed(0)}% from last week`;
+      ctx.fillStyle = '#35D07F'; // Green for positive
+    } else if (change < 0) {
+      changeText = `↓ ${Math.abs(change).toFixed(0)}% from last week`;
+      ctx.fillStyle = '#FF6B6B'; // Red for negative
+    }
+  }
+  ctx.fillText(changeText, 20, 140);
+  ctx.fillStyle = '#FFFFFF'; // Reset color
+  
+  // Add streak information
+  ctx.fillStyle = '#FBCC5C'; // Celo gold
+  ctx.font = 'bold 16px Arial';
+  ctx.fillText('Streak Information', 20, 180);
+  
+  ctx.fillStyle = '#FFFFFF';
+  ctx.font = '16px Arial';
+  ctx.fillText(`Current Streak: ${streakInfo.currentStreak} days`, 20, 210);
+  ctx.fillText(`Longest Streak: ${streakInfo.longestStreak} days`, 20, 240);
+  
+  // Add "Powered by Celo" badge
+  ctx.fillStyle = '#35D07F'; // Celo green
+  ctx.font = 'bold 12px Arial';
+  ctx.fillText('Powered by Celo', width - 120, height - 20);
+  
+  // Convert canvas to buffer
+  return canvas.toBuffer('image/png');
+};
+
+// Generate leaderboard image
+export const generateLeaderboard = async (
+  leaderboardData: Array<{ username: string; contributions: number }>
+): Promise<Buffer> => {
+  // Canvas dimensions
+  const width = 600;
+  const height = 320;
+  
+  // Create canvas
+  const canvas = createCanvas(width, height);
+  const ctx = canvas.getContext('2d');
+  
+  // Fill background
+  ctx.fillStyle = '#2E3338'; // Celo dark color
+  ctx.fillRect(0, 0, width, height);
+  
+  // Add title
+  ctx.fillStyle = '#FFFFFF';
+  ctx.font = 'bold 20px Arial';
+  ctx.fillText('Celo GitHub Contribution Leaderboard', 20, 40);
+  
+  // Display top contributors
+  const topContributors = leaderboardData.slice(0, 10); // Top 10
+  
+  ctx.font = '16px Arial';
+  
+  topContributors.forEach((contributor, index) => {
+    const y = 80 + index * 22;
+    
+    // Rank
+    ctx.fillStyle = index < 3 ? '#FBCC5C' : '#FFFFFF'; // Gold for top 3
+    ctx.fillText(`${index + 1}.`, 20, y);
+    
+    // Username
+    ctx.fillStyle = '#FFFFFF';
+    ctx.fillText(contributor.username, 50, y);
+    
+    // Contributions
+    ctx.fillText(`${contributor.contributions} contributions`, 300, y);
+  });
+  
+  // Add footer
+  ctx.fillStyle = '#35D07F'; // Celo green
+  ctx.font = 'bold 14px Arial';
+  ctx.fillText('🏆 Weekly Rewards for Top Builders', 20, height - 40);
+  
+  ctx.fillStyle = '#FFFFFF';
+  ctx.font = '12px Arial';
+  ctx.fillText('Keep shipping to climb the leaderboard!', 20, height - 20);
+  
+  // Convert canvas to buffer
+  return canvas.toBuffer('image/png');
+};

--- a/celo-consistency-frame/tailwind.config.js
+++ b/celo-consistency-frame/tailwind.config.js
@@ -1,0 +1,18 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        'celo-green': '#35D07F',
+        'celo-dark': '#2E3338',
+        'celo-gold': '#FBCC5C',
+      },
+    },
+  },
+  plugins: [],
+};

--- a/celo-consistency-frame/tsconfig.json
+++ b/celo-consistency-frame/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Solution for Issue #21: Show your consistency of building on Celo on GitHub

This PR implements a Farcaster frame that showcases GitHub contribution consistency for Celo developers.

### Features Implemented:
- GitHub profile integration with contribution visualization
- Weekly activity display in frame format
-  Leaderboard functionality for tracking top contributors
- Streak tracking mechanism (similar to Duolingo)
-  Support for weekly rewards for top 10 builders

### Technical Implementation:
- Next.js + TypeScript for the frontend and API routes
- Dynamic image generation for contribution graphs
- In-memory database (can be replaced with a proper DB in production)
- GitHub API integration for fetching user contribution data
- Responsive design with Tailwind CSS

### How to Test:
1. Clone the repository
2. Create a `.env` file with GitHub token and host URL
3. Run the development server
4. Enter a GitHub username to see the frame in action

This implementation follows the user flow described in the issue and provides all the requested functionality.